### PR TITLE
Constitution Link fix

### DIFF
--- a/agreements/disputing-an-agreement.md
+++ b/agreements/disputing-an-agreement.md
@@ -5,7 +5,7 @@ If you believe a party in the agreement has breached its terms, you have the opt
 1. Navigate to the specific Agreement page.
 2. Click on "Raise a Dispute" to start the process.
 
-From here, the [Dispute Resolution Process ](https://linked.md/v?u=ipfs://bafybeifiehkdnx5yhyrengoim5dhjclhxba6yhske6rwbm7dcv527gk524/DisputeResolutionProcess.linked.md)will take place. Parties involved can submit their evidence, judges will deliberate and propose a settlement.
+From here, the [Dispute Resolution Process ](https://github.com/nation3/law/blob/main/contracts/DisputeResolutionProcess.linked.md )will take place. Parties involved can submit their evidence, judges will deliberate and propose a settlement.
 
 If a party disagrees with the proposed settlement, they can appeal to the Nation3 DAO. The DAO has the authority to either accept or reject this appeal.
 
@@ -13,5 +13,5 @@ If a party disagrees with the proposed settlement, they can appeal to the Nation
 * If the appeal is rejected, the initially proposed settlement will be enforced.
 
 {% hint style="info" %}
-Currently only appeals regarding procedural violations can be submitted, check the [Dispute Resolution Process](https://linked.md/v?u=ipfs://bafybeifiehkdnx5yhyrengoim5dhjclhxba6yhske6rwbm7dcv527gk524/DisputeResolutionProcess.linked.md) for details.
+Currently only appeals regarding procedural violations can be submitted, check the [Dispute Resolution Process](https://github.com/nation3/law/blob/main/contracts/DisputeResolutionProcess.linked.md ) for details.
 {% endhint %}

--- a/agreements/what-is-a-nation3-agreement.md
+++ b/agreements/what-is-a-nation3-agreement.md
@@ -10,6 +10,6 @@ Each party puts a specific amount of assets as collateral when entering the agre
 
 All parties in an Agreement are bound by its terms. If they breach those terms, they can be taken to a Nation3 Court (ultimately, the [supreme-court.md](../legal-system/supreme-court.md "mention")) for dispute resolution.
 
-The terms of the agreement terms are set out in English, typically using  [Linked Markdown](https://linked.md) for clear formatting. The terms can include any clause agreed upon the parties, but must adhere to Nation3 [law.md](../legal-system/law.md "mention") and any other applicable laws.
+The terms of the agreement terms are set out in English, typically using  [Linked Markdown](https://github.com/linkedmd) for clear formatting. The terms can include any clause agreed upon the parties, but must adhere to Nation3 [law.md](../legal-system/law.md "mention") and any other applicable laws.
 
 Nation3 Agreements can cover all types of contracts, clearly defining each party's liability and offering a built-in, efficient way to resolve disputes in the internet age.\

--- a/citizenship/obtaining-reputation.md
+++ b/citizenship/obtaining-reputation.md
@@ -4,6 +4,6 @@ We have a system called NationCred that aggregates contributions to Nation3 acro
 
 NationCred is available to Nation3 citizens, and there are weekly payouts in $NATION to citizens who contribute.
 
-To become eligible for NationCred, head to the _#🎗-nationcred_ channel on [Discord](https://n3.gg/discord). Keep in mind it's only available to citizens, so you'll need to use the _#🤖-guild-join_ channel first to authenticate as a citizen.
+To become eligible for NationCred, head to the _#🎗-nationcred_ channel on [Discord](https://discord.com/invite/nation3-690584551239581708). Keep in mind it's only available to citizens, so you'll need to use the _#🤖-guild-join_ channel first to authenticate as a citizen.
 
 <figure><img src="../.gitbook/assets/ts-nc.png" alt=""><figcaption></figcaption></figure>

--- a/guilds/guardian-guild.md
+++ b/guilds/guardian-guild.md
@@ -17,5 +17,5 @@ The Nation3 DAO will hold yearly elections to choose the Guardian Guild.
 
 To apply, you'll need to create a new post in [this category within the Nation3 forum](https://forum.nation3.org/c/guardian-elections/18) including:
 
-* The following statement: “_I, \[your name], with adress \[your Ethereum address] understand, and agree to enter into,_ [_the agreement with the Nation3 DAO_](https://linked.md/v?u=ipfs://bafybeiaxrqmdntjn4n7txo5h3i4x2z3lyzhdzzrvvhqbrc5ozo476cpmnu/GuardianContract.linked.md) _to fulfil my role as a Guardian in the Guardian Guild of Nation3, should I be elected by community vote_”.
+* The following statement: “_I, \[your name], with adress \[your Ethereum address] understand, and agree to enter into,_ [_the agreement with the Nation3 DAO_](https://github.com/nation3/law/blob/main/contracts/GuardianContract.linked.md) _to fulfil my role as a Guardian in the Guardian Guild of Nation3, should I be elected by community vote_”.
 * Relevant experience in financial oversight, product/technical, Web3 and/or DAOs.

--- a/legal-system/constitution.md
+++ b/legal-system/constitution.md
@@ -1,6 +1,6 @@
 # 📜 Constitution
 
-The [Nation3 Constitution](https://linked.md/v?u=ipfs://bafybeidfupkrpzch3gwryqnaevratjc2nabhfoibygn5mmdpaylzbmajqu/Constitution.linked.md) is the world's first enforceable constitution from a cloud nation.&#x20;
+The [Nation3 Constitution](https://github.com/nation3/law/blob/main/Constitution.linked.md) is the world's first enforceable constitution from a cloud nation.&#x20;
 
 ### Key points
 


### PR DESCRIPTION
This change will direct the link pointing directly to the GitHub file, since the linked.md domain is no longer operational

closes #2 